### PR TITLE
fix: avoid NullPointerException in DexClassLoader on Android < API 26

### DIFF
--- a/app/src/main/java/com/aoya/telegami/Telegami.kt
+++ b/app/src/main/java/com/aoya/telegami/Telegami.kt
@@ -44,7 +44,7 @@ object Telegami {
         newModule.setReadOnly()
 
         this.classLoader =
-            DexClassLoader(newModule.absolutePath, null, null, context.classLoader)
+            DexClassLoader(newModule.absolutePath, context.codeCacheDir.absolutePath, null, context.classLoader)
         this.hookManager = HookManager()
         this.packageName = context.packageName
         this.db = AppDatabase.getDatabase(context)


### PR DESCRIPTION
On Android versions prior to 8.0 (API 26), the DexClassLoader constructor internally invokes `new File(optimizedDirectory)`. If the `optimizedDirectory` parameter is null, it triggers a `java.lang.NullPointerException`, leading to module initialization failure.

Although this parameter is deprecated and can be null since API 26 according to official docs, some API 26 devices (early builds or OEM versions) still retain the old implementation.

This commit replaces the null argument with `context.codeCacheDir.absolutePath` to ensure compatibility across all Android versions.

Ref: https://developer.android.com/reference/dalvik/system/DexClassLoader#DexClassLoader